### PR TITLE
Parameterize --os-variant flag to virt-install

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,7 @@ version 0.2
 * The `NETWORK` variable is the first three octets of a network address, and should not conflict with an existing KVM network - configuration of `NETWORK_2` is optional.
 * The variables `VCPUS`, `MEMORY`, and `DISK`, should be sized appropriately for your environment 
 * The ANSIBLE_PLAY function and DISK_CUSTOMIZATION functions should not be empty, even if there is a single line that does nothing, such as `echo -n ""`. 
+* The `OS_VARIANT` variable can optionally be set to define the value passed to the --os-variant flag for the virt-install application. The default value is `linux2022`. You can view available OS variants by running `osinfo-query os`.
 
 .Procedure
 

--- a/conf/rhel-9-large.conf
+++ b/conf/rhel-9-large.conf
@@ -12,6 +12,7 @@ NETWORK_2=10.10.91
 NAME=rhel-9-large-${ID}
 DISK=/var/lib/libvirt/images/${NAME}.qcow2
 TEMPLATE=/var/lib/libvirt/images/templates/rhel-baseos-9.0-x86_64-kvm.qcow2
+OS_VARIANT=rhl9
 
 function DISK_CUSTOMIZATIONS {
 export LIBGUESTFS_BACKEND=direct

--- a/scripts/init-vm.sh
+++ b/scripts/init-vm.sh
@@ -186,7 +186,7 @@ if [ ! -z "${NETWORK_NAME_2}" ] && [ ! -z "${NETWORK_2}" ]; then
 --network network=${NETWORK_NAME_2} \
 --name ${NAME} \
 --ram ${MEMORY} \
---os-variant=linux2022 \
+--os-variant=${OS_VARIANT:-linux2022} \
 --dry-run --print-xml > /tmp/${NAME}.xml
 
 else
@@ -198,7 +198,7 @@ else
 --network network=${NETWORK_NAME} \
 --name ${NAME} \
 --ram ${MEMORY} \
---os-variant=linux2022 \
+--os-variant=${OS_VARIANT:-linux2022} \
 --dry-run --print-xml > /tmp/${NAME}.xml
 
 fi


### PR DESCRIPTION
When deploying with other virt-install versions, it's possible that not
all os-variants might exist on the system. This change updates the
hardcoded linux2022 os-variant to be dynamic, leaving the default set to
the previous version for backwards compatibility.

Also changed is an update to the rhel-9-large configuration template
with the new OS_VARIANT parameter and setting the value to 'rhl9'. All
available os-variants available to the system can be found by running
'osinfo-query os'.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
