### PR TITLE
Allow custom configurations to be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ansible/ansible.log
 ansible/hosts
 ansible/locked-vars.yml
+conf/custom-*.conf


### PR DESCRIPTION
Creating custom configuration files prefixed by custom- will now be
ignored by git to help keep working environments cleaner.
